### PR TITLE
Fix to get header certainly

### DIFF
--- a/player_windows.go
+++ b/player_windows.go
@@ -95,15 +95,18 @@ func (p *player) Write(data []uint8) (int, error) {
 	p.upperBuffer = append(p.upperBuffer, data[:n]...)
 	for len(p.upperBuffer) >= lowerBufferUnitSize {
 		var headerToWrite *header
-		for _, h := range p.headers {
-			// TODO: Need to check WHDR_DONE?
-			if h.waveHdr.dwFlags&whdrInqueue == 0 {
-				headerToWrite = h
-				break
+		for {
+			for _, h := range p.headers {
+				// TODO: Need to check WHDR_DONE?
+				if h.waveHdr.dwFlags&whdrInqueue == 0 {
+					headerToWrite = h
+					break
+				}
 			}
-		}
-		if headerToWrite == nil {
-			// This can happen (hajimehoshi/ebiten#207)
+			if headerToWrite == nil {
+				// This can happen (hajimehoshi/ebiten#207)
+				continue
+			}
 			break
 		}
 		if err := headerToWrite.Write(p.out, p.upperBuffer[:lowerBufferUnitSize]); err != nil {


### PR DESCRIPTION
I'd like to inform to you first that I'm not familiar with sound programming for Windows. If you think that this PR is nonsense, please reject.

Hi, I'm going to switch a player of [pollydent](https://github.com/bamchoh/pollydent) from homemade player to your sound player library 'oto'. But oto does not play a sound completely sometimes. As far as I investigate it, this issue occurs when headerToWrite in player_windows.go is nil in playing the sound. I added for loop for getting header certainly. Then, this issue does not occur. I think if player is still playing, Getting header need to wait. But this loop needs CPU power. So I think there are better solution than my solution like callback function. But I don't know how I can solve this issue with callback function. I'm sorry for that.