### PR TITLE
openal: avoid possibility of panic by index out of bounds at player.Close

### DIFF
--- a/player_openal.go
+++ b/player_openal.go
@@ -221,7 +221,9 @@ func (p *player) Close() error {
 
 	C.alSourceStop(p.alSource)
 	C.alDeleteSources(1, &p.alSource)
-	C.alDeleteBuffers(C.ALsizei(numBufs), &p.bufs[0])
+	if len(p.bufs) != 0 {
+		C.alDeleteBuffers(C.ALsizei(numBufs), &p.bufs[0])
+	}
 	C.alcDestroyContext(p.alContext.cALCcontext())
 
 	if err := p.alDevice.getError(); err != nil {


### PR DESCRIPTION
Hi, @hajimehoshi !

I sometimes faced panic by index out of bounds in player.Close function.
I don't see this problem in Linux, but only in OSX so far.

for the time being, I inserted checking length of p.bufs before its use.
It seems to help not to cause panic, but since I'm not sure the reason of index out of bounds occurs, i'm not sure this is applicable correction.

I'm very happy if you give some comment!