### PR TITLE
Abort function for io.Copy

### DIFF
--- a/player.go
+++ b/player.go
@@ -15,10 +15,7 @@
 // Package oto offers io.Writer to play sound on multiple platforms.
 package oto
 
-import (
-	"fmt"
-	"time"
-)
+import "time"
 
 // Player is a PCM (pulse-code modulation) audio player. It implements io.Writer, use Write method
 // to play samples.
@@ -107,7 +104,7 @@ func (p *Player) Write(data []uint8) (int, error) {
 		select {
 		default:
 		case <-p.abortCh:
-			return 0, fmt.Errorf("Aborted")
+			return written, nil
 		}
 		n, err := p.player.Write(data)
 		written += n

--- a/player.go
+++ b/player.go
@@ -125,6 +125,7 @@ func (p *Player) Write(data []uint8) (int, error) {
 	return written, nil
 }
 
+// Abort aborts the playing music.
 func (p *Player) Abort() {
 	p.abortCh <- true
 }


### PR DESCRIPTION
Hello @hajimehoshi !

I was moved by the method of playing music by combining [go-mp3](https://github.com/hajimehoshi/go-mp3) and oto library with io.Copy. [here](http://qiita.com/hajimehoshi/items/9f3b7186ec0b8e2850a4)
I would like to create a mechanism like jukebox using this technique and incorporate it into my game using [ebiten](https://github.com/hajimehoshi/ebiten).

So I searched for a way to interrupt music play by interrupting io.Copy and implemented.
[Here](https://gist.github.com/KemoKemo/ab3776224e7557b389ed07595546f78c) is an example of an interruption sample written based on your sample.

Would you please give me comments or advice?