### PR TITLE
android: remove outdated comments

### DIFF
--- a/player_android.go
+++ b/player_android.go
@@ -108,7 +108,6 @@ static char* initAudioTrack(uintptr_t java_vm, uintptr_t jni_env,
           android_media_AudioManager_STREAM_MUSIC,
           sampleRate, channel, encoding, *bufferSize,
           android_media_AudioTrack_MODE_STREAM);
-  // Note that *audioTrack will never be released.
   *audioTrack = (*env)->NewGlobalRef(env, tmpAudioTrack);
   (*env)->DeleteLocalRef(env, tmpAudioTrack);
 


### PR DESCRIPTION
Remove a comment that may not be necessary anymore because of fix #27.

I'm so sorry to say that I forgot to do this at #28 ...