### PR TITLE
Implement Context/Player for multiple playback sources

### DIFF
--- a/context.go
+++ b/context.go
@@ -1,0 +1,160 @@
+// Copyright 2019 The Oto Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oto
+
+import (
+	"errors"
+	"io"
+	"sync"
+	"time"
+
+	"github.com/hajimehoshi/oto/internal/mux"
+)
+
+type Context struct {
+	driverWriter *driverWriter
+	mux          *mux.Mux
+	errCh        chan error
+}
+
+var (
+	theContext *Context
+	contextM   sync.Mutex
+)
+
+var errClosed = errors.New("closed")
+
+// NewContext creates a new context, that creates and holds ready-to-use Player objects.
+//
+// The sampleRate argument specifies the number of samples that should be played during one second.
+// Usual numbers are 44100 or 48000.
+//
+// The channelNum argument specifies the number of channels. One channel is mono playback. Two
+// channels are stereo playback. No other values are supported.
+//
+// The bitDepthInBytes argument specifies the number of bytes per sample per channel. The usual value
+// is 2. Only values 1 and 2 are supported.
+//
+// The bufferSizeInBytes argument specifies the size of the buffer of the Context. This means, how
+// many bytes can Context remember before actually playing them. Bigger buffer can reduce the number
+// of Player's Write calls, thus reducing CPU time. Smaller buffer enables more precise timing. The
+// longest delay between when samples were written and when they started playing is equal to the size
+// of the buffer.
+func NewContext(sampleRate, channelNum, bitDepthInBytes, bufferSizeInBytes int) (*Context, error) {
+	contextM.Lock()
+	defer contextM.Unlock()
+
+	if theContext != nil {
+		panic("oto: NewContext can be called only once")
+	}
+
+	d, err := newDriver(sampleRate, channelNum, bitDepthInBytes, bufferSizeInBytes)
+	if err != nil {
+		return nil, err
+	}
+	dw := &driverWriter{
+		driver:         d,
+		bufferSize:     bufferSizeInBytes,
+		bytesPerSecond: sampleRate * channelNum * bitDepthInBytes,
+	}
+	c := &Context{
+		driverWriter: dw,
+		mux:          mux.New(channelNum, bitDepthInBytes),
+		errCh:        make(chan error),
+	}
+	theContext = c
+	go func() {
+		if _, err := io.Copy(c.driverWriter, c.mux); err != nil {
+			c.errCh <- err
+		}
+		close(c.errCh)
+	}()
+	return c, nil
+}
+
+// NewPlayer is a short-hand of creating a Context by NewContext and a Player by the context's NewPlayer.
+func NewPlayer(sampleRate, channelNum, bitDepthInBytes, bufferSizeInBytes int) (*Player, error) {
+	c, err := NewContext(sampleRate, channelNum, bitDepthInBytes, bufferSizeInBytes)
+	if err != nil {
+		return nil, err
+	}
+	return c.NewPlayer(), nil
+}
+
+// NewPlayer creates a new, ready-to-use Player belonging to the Context.
+func (c *Context) NewPlayer() *Player {
+	p := newPlayer(c)
+	c.mux.AddSource(p.r)
+	return p
+}
+
+// Close closes the Context and its Players and frees any resources associated with it. The Context is no longer
+// usable after calling Close.
+func (c *Context) Close() error {
+	if err := c.driverWriter.Close(); err != nil {
+		return err
+	}
+	if err := c.mux.Close(); err != nil {
+		return err
+	}
+	return <-c.errCh
+}
+
+type driverWriter struct {
+	driver         *driver
+	bufferSize     int
+	bytesPerSecond int
+
+	m sync.Mutex
+}
+
+func (d *driverWriter) Write(buf []byte) (int, error) {
+	d.m.Lock()
+	defer d.m.Unlock()
+
+	written := 0
+	for len(buf) > 0 {
+		if d.driver == nil {
+			return written, errClosed
+		}
+		n, err := d.driver.TryWrite(buf)
+		written += n
+		if err != nil {
+			return written, err
+		}
+		buf = buf[n:]
+		// When not all buf is written, the underlying buffer is full.
+		// Mitigate the busy loop by sleeping (#10).
+		if len(buf) > 0 {
+			t := time.Second * time.Duration(d.bufferSize) / time.Duration(d.bytesPerSecond) / 8
+			time.Sleep(t)
+		}
+	}
+	return written, nil
+}
+
+func (d *driverWriter) Close() error {
+	d.m.Lock()
+	defer d.m.Unlock()
+
+	// Close should be wait until the buffer data is consumed (#36).
+	// This is the simplest (but ugly) fix.
+	// TODO: Implement player's Close to wait the buffer played.
+	time.Sleep(time.Second * time.Duration(d.bufferSize) / time.Duration(d.bytesPerSecond))
+	if err := d.driver.Close(); err != nil {
+		return err
+	}
+	return nil
+}

--- a/example/main.go
+++ b/example/main.go
@@ -1,0 +1,177 @@
+// Copyright 2019 The Oto Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build example
+
+package main
+
+import (
+	"flag"
+	"io"
+	"math"
+	"sync"
+	"time"
+
+	"github.com/hajimehoshi/oto"
+)
+
+var (
+	sampleRate      = flag.Int("samplerate", 44100, "sample rate")
+	channelNum      = flag.Int("channelnum", 2, "number of channel")
+	bitDepthInBytes = flag.Int("bitdepthinbytes", 2, "bit depth in bytes")
+)
+
+type SineWave struct {
+	freq   float64
+	length int64
+	pos    int64
+
+	remaining []byte
+}
+
+func NewSineWave(freq float64, duration time.Duration) *SineWave {
+	l := int64(*channelNum) * int64(*bitDepthInBytes) * int64(*sampleRate) * int64(duration) / int64(time.Second)
+	l = l / 4 * 4
+	return &SineWave{
+		freq:   freq,
+		length: l,
+	}
+}
+
+func (s *SineWave) Read(buf []byte) (int, error) {
+	if len(s.remaining) > 0 {
+		n := copy(buf, s.remaining)
+		s.remaining = s.remaining[n:]
+		return n, nil
+	}
+
+	if s.pos == s.length {
+		return 0, io.EOF
+	}
+
+	eof := false
+	if s.pos+int64(len(buf)) > s.length {
+		buf = buf[:s.length-s.pos]
+		eof = true
+	}
+
+	var origBuf []byte
+	if len(buf)%4 > 0 {
+		origBuf = buf
+		buf = make([]byte, len(origBuf)+4-len(origBuf)%4)
+	}
+
+	length := float64(*sampleRate) / float64(s.freq)
+
+	num := (*bitDepthInBytes) * (*channelNum)
+	p := s.pos / int64(num)
+	switch *bitDepthInBytes {
+	case 1:
+		for i := 0; i < len(buf)/num; i++ {
+			const max = 127
+			b := int(math.Sin(2*math.Pi*float64(p)/length) * 0.3 * max)
+			for ch := 0; ch < *channelNum; ch++ {
+				buf[num*i+ch] = byte(b+128)
+			}
+			p++
+		}
+	case 2:
+		for i := 0; i < len(buf)/num; i++ {
+			const max = 32767
+			b := int16(math.Sin(2*math.Pi*float64(p)/length) * 0.3 * max)
+			for ch := 0; ch < *channelNum; ch++ {
+				buf[num*i+2*ch] = byte(b)
+				buf[num*i+1+2*ch] = byte(b >> 8)
+			}
+			p++
+		}
+	}
+
+	s.pos += int64(len(buf))
+
+	n := len(buf)
+	if origBuf != nil {
+		n = copy(origBuf, buf)
+		s.remaining = buf[n:]
+	}
+
+	if eof {
+		return n, io.EOF
+	}
+	return n, nil
+}
+
+func play(context *oto.Context, freq float64, duration time.Duration) error {
+	p := context.NewPlayer()
+	s := NewSineWave(freq, duration)
+	if _, err := io.Copy(p, s); err != nil {
+		return err
+	}
+	if err := p.Close(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func run() error {
+	const (
+		freqC = 523.3
+		freqE = 659.3
+		freqG = 784.0
+	)
+
+	c, err := oto.NewContext(*sampleRate, *channelNum, *bitDepthInBytes, 4096)
+	if err != nil {
+		return err
+	}
+
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		if err := play(c, freqC, 3*time.Second); err != nil {
+			panic(err)
+		}
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		time.Sleep(1 * time.Second)
+		if err := play(c, freqE, 3*time.Second); err != nil {
+			panic(err)
+		}
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		time.Sleep(2 * time.Second)
+		if err := play(c, freqG, 3*time.Second); err != nil {
+			panic(err)
+		}
+	}()
+
+	wg.Wait()
+	c.Close()
+	return nil
+}
+
+func main() {
+	flag.Parse()
+	if err := run(); err != nil {
+		panic(err)
+	}
+}

--- a/internal/mux/mux.go
+++ b/internal/mux/mux.go
@@ -1,0 +1,153 @@
+// Copyright 2019 The Oto Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mux
+
+import (
+	"bufio"
+	"io"
+	"runtime"
+	"sync"
+)
+
+// Mux is a multiplexer for multiple io.Reader objects.
+type Mux struct {
+	channelNum      int
+	bitDepthInBytes int
+	readers         map[io.Reader]*bufio.Reader
+	closed          bool
+
+	m sync.RWMutex
+}
+
+func New(channelNum, bitDepthInBytes int) *Mux {
+	m := &Mux{
+		channelNum:      channelNum,
+		bitDepthInBytes: bitDepthInBytes,
+		readers:         map[io.Reader]*bufio.Reader{},
+	}
+	runtime.SetFinalizer(m, (*Mux).Close)
+	return m
+}
+
+func (m *Mux) Read(buf []byte) (int, error) {
+	m.m.Lock()
+	defer m.m.Unlock()
+
+	if m.closed {
+		return 0, io.EOF
+	}
+
+	if len(m.readers) == 0 {
+		return 0, nil
+	}
+
+	bs := m.channelNum * m.bitDepthInBytes
+	l := len(buf)
+	l = l / bs * bs // Adjust the length in order not to mix different channels.
+
+	bufs := map[*bufio.Reader][]byte{}
+	for _, p := range m.readers {
+		peeked, err := p.Peek(l)
+		if err != nil && err != bufio.ErrBufferFull && err != io.EOF {
+			return 0, err
+		}
+		if l > len(peeked) {
+			l = len(peeked)
+			l = l / bs * bs
+		}
+		bufs[p] = peeked[:l]
+	}
+
+	if l == 0 {
+		return 0, nil
+	}
+
+	for _, p := range m.readers {
+		if _, err := p.Discard(l); err != nil {
+			return 0, err
+		}
+	}
+
+	switch m.bitDepthInBytes {
+	case 1:
+		const (
+			max    = 127
+			min    = -128
+			offset = 128
+		)
+		for i := 0; i < l; i++ {
+			x := 0
+			for _, b := range bufs {
+				x += int(b[i]) - offset
+			}
+			if x > max {
+				x = max
+			}
+			if x < min {
+				x = min
+			}
+			buf[i] = byte(x + offset)
+		}
+	case 2:
+		const (
+			max = (1 << 15) - 1
+			min = -(1 << 15)
+		)
+		for i := 0; i < l/2; i++ {
+			x := 0
+			for _, b := range bufs {
+				x += int(int16(b[2*i]) | (int16(b[2*i+1]) << 8))
+			}
+			if x > max {
+				x = max
+			}
+			if x < min {
+				x = min
+			}
+			buf[2*i] = byte(x)
+			buf[2*i+1] = byte(x >> 8)
+		}
+	default:
+		panic("not reached")
+	}
+
+	return l, nil
+}
+
+func (m *Mux) Close() error {
+	m.m.Lock()
+	m.readers = nil
+	m.closed = true
+	m.m.Unlock()
+	return nil
+}
+
+func (m *Mux) AddSource(source io.Reader) {
+	m.m.Lock()
+	if m.closed {
+		panic("mux: already closed")
+	}
+	m.readers[source] = bufio.NewReaderSize(source, 256)
+	m.m.Unlock()
+}
+
+func (m *Mux) RemoveSource(source io.Reader) {
+	m.m.Lock()
+	if m.closed {
+		panic("mux: already closed")
+	}
+	delete(m.readers, source)
+	m.m.Unlock()
+}

--- a/internal/mux/mux.go
+++ b/internal/mux/mux.go
@@ -128,6 +128,7 @@ func (m *Mux) Read(buf []byte) (int, error) {
 
 func (m *Mux) Close() error {
 	m.m.Lock()
+	runtime.SetFinalizer(m, nil)
 	m.readers = nil
 	m.closed = true
 	m.m.Unlock()

--- a/internal/mux/mux_test.go
+++ b/internal/mux/mux_test.go
@@ -1,0 +1,123 @@
+// Copyright 2019 The Oto Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mux_test
+
+import (
+	"bytes"
+	"io"
+	"reflect"
+	"testing"
+
+	"github.com/hajimehoshi/oto/internal/mux"
+)
+
+func TestMux8Bits(t *testing.T) {
+	cases := []struct {
+		Sources [][]byte
+		Out     []byte
+	}{
+		{
+			Sources: [][]byte{
+				{128, 129, 130},
+				{131, 132, 133},
+			},
+			Out: []byte{131, 133, 135},
+		},
+		{
+			Sources: [][]byte{
+				{128, 129, 130},
+				{128, 127, 126},
+				{128, 128, 128},
+			},
+			Out: []byte{128, 128, 128},
+		},
+	}
+	for _, c := range cases {
+		m := mux.New(1, 1)
+		for _, s := range c.Sources {
+			m.AddSource(bytes.NewReader(s))
+		}
+
+		buf := make([]byte, len(c.Sources[0]))
+		if _, err := io.ReadFull(m, buf); err != nil {
+			t.Fatal(err)
+		}
+
+		got := buf
+		want := c.Out
+		if !bytes.Equal(got, want) {
+			t.Errorf("got: %v, want: %v", got, want)
+		}
+		m.Close()
+	}
+}
+
+func int16sToBytes(buf []int16) []byte {
+	bs := make([]byte, len(buf)*2)
+	for i, b := range buf {
+		bs[2*i] = byte(b)
+		bs[2*i+1] = byte(b >> 8)
+	}
+	return bs
+}
+
+func bytesToInt16s(buf []byte) []int16 {
+	is := make([]int16, len(buf)/2)
+	for i := 0; i < len(is); i++ {
+		is[i] = int16(buf[2*i]) | (int16(buf[2*i+1]) << 8)
+	}
+	return is
+}
+
+func TestMux16Bits(t *testing.T) {
+	cases := []struct {
+		Sources [][]int16
+		Out     []int16
+	}{
+		{
+			Sources: [][]int16{
+				{0, 1, 2},
+				{3, 4, 5},
+			},
+			Out: []int16{3, 5, 7},
+		},
+		{
+			Sources: [][]int16{
+				{0, 1, 2},
+				{0, -1, -2},
+				{0, 0, 0},
+			},
+			Out: []int16{0, 0, 0},
+		},
+	}
+	for _, c := range cases {
+		m := mux.New(1, 2)
+		for _, s := range c.Sources {
+			m.AddSource(bytes.NewReader(int16sToBytes(s)))
+		}
+
+		buf := make([]byte, len(c.Sources[0])*2)
+		if _, err := io.ReadFull(m, buf); err != nil {
+			t.Fatal(err)
+		}
+
+		got := bytesToInt16s(buf)
+		want := c.Out
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("got: %v, want: %v", got, want)
+		}
+		m.Close()
+	}
+}

--- a/player.go
+++ b/player.go
@@ -16,51 +16,28 @@
 package oto
 
 import (
-	"time"
+	"io"
+	"runtime"
 )
 
-// Player is a PCM (pulse-code modulation) audio player. It implements io.Writer, use Write method
-// to play samples.
+// Player is a PCM (pulse-code modulation) audio player.
+// Player implements io.WriteCloser.
+// Use Write method to play samples.
 type Player struct {
-	driver          *driver
-	sampleRate      int
-	channelNum      int
-	bitDepthInBytes int
-	bufferSize      int
+	context *Context
+	r       *io.PipeReader
+	w       *io.PipeWriter
 }
 
-// NewPlayer creates a new, ready-to-use Player.
-//
-// The sampleRate argument specifies the number of samples that should be played during one second.
-// Usual numbers are 44100 or 48000.
-//
-// The channelNum argument specifies the number of channels. One channel is mono playback. Two
-// channels are stereo playback. No other values are supported.
-//
-// The bitDepthInBytes argument specifies the number of bytes per sample per channel. The usual value
-// is 2. Only values 1 and 2 are supported.
-//
-// The bufferSizeInBytes argument specifies the size of the buffer of the Player. This means, how
-// many bytes can Player remember before actually playing them. Bigger buffer can reduce the number
-// of Write calls, thus reducing CPU time. Smaller buffer enables more precise timing. The longest
-// delay between when samples were written and when they started playing is equal to the size of the
-// buffer.
-func NewPlayer(sampleRate, channelNum, bitDepthInBytes, bufferSizeInBytes int) (*Player, error) {
-	d, err := newDriver(sampleRate, channelNum, bitDepthInBytes, bufferSizeInBytes)
-	if err != nil {
-		return nil, err
+func newPlayer(context *Context) *Player {
+	r, w := io.Pipe()
+	p := &Player{
+		context: context,
+		r:       r,
+		w:       w,
 	}
-	return &Player{
-		driver:          d,
-		sampleRate:      sampleRate,
-		channelNum:      channelNum,
-		bitDepthInBytes: bitDepthInBytes,
-		bufferSize:      bufferSizeInBytes,
-	}, nil
-}
-
-func (p *Player) bytesPerSec() int {
-	return p.sampleRate * p.channelNum * p.bitDepthInBytes
+	runtime.SetFinalizer(p, (*Player).Close)
+	return p
 }
 
 // Write writes PCM samples to the Player.
@@ -79,33 +56,26 @@ func (p *Player) bytesPerSec() int {
 // the buffer.
 //
 // Note, that the Player won't start playing anything until the buffer is full.
-func (p *Player) Write(data []byte) (int, error) {
-	written := 0
-	for len(data) > 0 {
-		n, err := p.driver.TryWrite(data)
-		written += n
-		if err != nil {
-			return written, err
-		}
-		data = data[n:]
-		// When not all data is written, the underlying buffer is full.
-		// Mitigate the busy loop by sleeping (#10).
-		if len(data) > 0 {
-			t := time.Second * time.Duration(p.bufferSize) / time.Duration(p.bytesPerSec()) / 8
-			time.Sleep(t)
-		}
-	}
-	return written, nil
+func (p *Player) Write(buf []byte) (int, error) {
+	return p.w.Write(buf)
 }
 
 // Close closes the Player and frees any resources associated with it. The Player is no longer
 // usable after calling Close.
 func (p *Player) Close() error {
-	// Close should be wait until the buffer data is consumed (#36).
-	// This is the simplest (but ugly) fix.
-	// TODO: Implement player's Close to wait the buffer played.
-	time.Sleep(time.Second * time.Duration(p.bufferSize) / time.Duration(p.bytesPerSec()))
-	return p.driver.Close()
+	// Close the pipe writer before RemoveSource, or Read-ing in the mux takes forever.
+	if err := p.w.Close(); err != nil {
+		return err
+	}
+
+	p.context.mux.RemoveSource(p.r)
+	p.context = nil
+
+	// Close the pipe reader after RemoveSource, or ErrClosedPipe happens at Read-ing.
+	if err := p.r.Close(); err != nil {
+		return err
+	}
+	return nil
 }
 
 func max(a, b int) int {

--- a/player.go
+++ b/player.go
@@ -63,6 +63,13 @@ func (p *Player) Write(buf []byte) (int, error) {
 // Close closes the Player and frees any resources associated with it. The Player is no longer
 // usable after calling Close.
 func (p *Player) Close() error {
+	runtime.SetFinalizer(p, nil)
+
+	// Already closed
+	if p.context == nil {
+		return nil
+	}
+
 	// Close the pipe writer before RemoveSource, or Read-ing in the mux takes forever.
 	if err := p.w.Close(); err != nil {
 		return err


### PR DESCRIPTION
This implements #47

CC @faiface @Noofbiz 

I'll brush up, add tests and then would like to ask you to review.

EDIT: What I did in this change is:

* Add `Context`. That has a `driverWriter` to write bytes to the driver, and a `Mux` that reads multiplexed bytes from multiple sources. When a `Context` is created, run a goroutine to execute the loop of `io.Copy(driverWriter, Mux)`.
* Modify `Player` that has a reader and a writer from `io.Pipe`. The writer accepts the Player's user input and the reader is used at `mux`.
* Add `Mux` that multiplexes bytes from multiple sources (Player's reader in this case). This is in a separated internal package with tests. `Mux` also manages registration and de-registiration of the sources.
* Add `example/main.go` to test multiple players.