### PR TITLE
Rename bytesPerSample -> bitDepthInBytes

### DIFF
--- a/driver_openal.go
+++ b/driver_openal.go
@@ -89,23 +89,23 @@ func (a alDevice) cALCDevice() *C.ALCdevice {
 	return (*C.struct_ALCdevice_struct)(unsafe.Pointer(a))
 }
 
-func alFormat(channelNum, bytesPerSample int) C.ALenum {
+func alFormat(channelNum, bitDepthInBytes int) C.ALenum {
 	switch {
-	case channelNum == 1 && bytesPerSample == 1:
+	case channelNum == 1 && bitDepthInBytes == 1:
 		return C.AL_FORMAT_MONO8
-	case channelNum == 1 && bytesPerSample == 2:
+	case channelNum == 1 && bitDepthInBytes == 2:
 		return C.AL_FORMAT_MONO16
-	case channelNum == 2 && bytesPerSample == 1:
+	case channelNum == 2 && bitDepthInBytes == 1:
 		return C.AL_FORMAT_STEREO8
-	case channelNum == 2 && bytesPerSample == 2:
+	case channelNum == 2 && bitDepthInBytes == 2:
 		return C.AL_FORMAT_STEREO16
 	}
-	panic(fmt.Sprintf("oto: invalid channel num (%d) or bytes per sample (%d)", channelNum, bytesPerSample))
+	panic(fmt.Sprintf("oto: invalid channel num (%d) or bytes per sample (%d)", channelNum, bitDepthInBytes))
 }
 
 const numBufs = 2
 
-func newDriver(sampleRate, channelNum, bytesPerSample, bufferSizeInBytes int) (*driver, error) {
+func newDriver(sampleRate, channelNum, bitDepthInBytes, bufferSizeInBytes int) (*driver, error) {
 	name := C.alGetString(C.ALC_DEFAULT_DEVICE_SPECIFIER)
 	d := alDevice(unsafe.Pointer(C.alcOpenDevice((*C.ALCchar)(name))))
 	if d == 0 {
@@ -135,7 +135,7 @@ func newDriver(sampleRate, channelNum, bytesPerSample, bufferSizeInBytes int) (*
 		alSource:     s,
 		alDeviceName: C.GoString((*C.char)(name)),
 		sampleRate:   sampleRate,
-		alFormat:     alFormat(channelNum, bytesPerSample),
+		alFormat:     alFormat(channelNum, bitDepthInBytes),
 		bufs:         make([]C.ALuint, numBufs),
 		bufferSize:   bufferSizeInBytes,
 	}

--- a/driver_windows.go
+++ b/driver_windows.go
@@ -59,14 +59,14 @@ type driver struct {
 	bufferSize int
 }
 
-func newDriver(sampleRate, channelNum, bytesPerSample, bufferSizeInBytes int) (*driver, error) {
-	numBlockAlign := channelNum * bytesPerSample
+func newDriver(sampleRate, channelNum, bitDepthInBytes, bufferSizeInBytes int) (*driver, error) {
+	numBlockAlign := channelNum * bitDepthInBytes
 	f := &waveformatex{
 		wFormatTag:      waveFormatPCM,
 		nChannels:       uint16(channelNum),
 		nSamplesPerSec:  uint32(sampleRate),
 		nAvgBytesPerSec: uint32(sampleRate * numBlockAlign),
-		wBitsPerSample:  uint16(bytesPerSample * 8),
+		wBitsPerSample:  uint16(bitDepthInBytes * 8),
 		nBlockAlign:     uint16(numBlockAlign),
 	}
 	w, err := waveOutOpen(f)

--- a/player.go
+++ b/player.go
@@ -22,11 +22,11 @@ import (
 // Player is a PCM (pulse-code modulation) audio player. It implements io.Writer, use Write method
 // to play samples.
 type Player struct {
-	driver         *driver
-	sampleRate     int
-	channelNum     int
-	bytesPerSample int
-	bufferSize     int
+	driver          *driver
+	sampleRate      int
+	channelNum      int
+	bitDepthInBytes int
+	bufferSize      int
 }
 
 // NewPlayer creates a new, ready-to-use Player.
@@ -37,7 +37,7 @@ type Player struct {
 // The channelNum argument specifies the number of channels. One channel is mono playback. Two
 // channels are stereo playback. No other values are supported.
 //
-// The bytesPerSample argument specifies the number of bytes per sample per channel. The usual value
+// The bitDepthInBytes argument specifies the number of bytes per sample per channel. The usual value
 // is 2. Only values 1 and 2 are supported.
 //
 // The bufferSizeInBytes argument specifies the size of the buffer of the Player. This means, how
@@ -45,22 +45,22 @@ type Player struct {
 // of Write calls, thus reducing CPU time. Smaller buffer enables more precise timing. The longest
 // delay between when samples were written and when they started playing is equal to the size of the
 // buffer.
-func NewPlayer(sampleRate, channelNum, bytesPerSample, bufferSizeInBytes int) (*Player, error) {
-	d, err := newDriver(sampleRate, channelNum, bytesPerSample, bufferSizeInBytes)
+func NewPlayer(sampleRate, channelNum, bitDepthInBytes, bufferSizeInBytes int) (*Player, error) {
+	d, err := newDriver(sampleRate, channelNum, bitDepthInBytes, bufferSizeInBytes)
 	if err != nil {
 		return nil, err
 	}
 	return &Player{
-		driver:         d,
-		sampleRate:     sampleRate,
-		channelNum:     channelNum,
-		bytesPerSample: bytesPerSample,
-		bufferSize:     bufferSizeInBytes,
+		driver:          d,
+		sampleRate:      sampleRate,
+		channelNum:      channelNum,
+		bitDepthInBytes: bitDepthInBytes,
+		bufferSize:      bufferSizeInBytes,
 	}, nil
 }
 
 func (p *Player) bytesPerSec() int {
-	return p.sampleRate * p.channelNum * p.bytesPerSample
+	return p.sampleRate * p.channelNum * p.bitDepthInBytes
 }
 
 // Write writes PCM samples to the Player.


### PR DESCRIPTION
`bytesPerSample` is confusing since this is ambiguous: this might mean the total bytes in all the channels of one sample, or the bytes in one channel of one sample.

I suggest to rename this to `bitDepthInBytes` to avoid confusion. `bitDepthInBytes` is the bytes in one channel of one sample.

@faiface , @Noofbiz Please take a look just in case.
