### PR TITLE
Allow context reuse after close

### DIFF
--- a/context.go
+++ b/context.go
@@ -103,6 +103,8 @@ func (c *Context) NewPlayer() *Player {
 // Close closes the Context and its Players and frees any resources associated with it. The Context is no longer
 // usable after calling Close.
 func (c *Context) Close() error {
+	theContext = nil
+
 	if err := c.driverWriter.Close(); err != nil {
 		return err
 	}

--- a/context.go
+++ b/context.go
@@ -103,7 +103,9 @@ func (c *Context) NewPlayer() *Player {
 // Close closes the Context and its Players and frees any resources associated with it. The Context is no longer
 // usable after calling Close.
 func (c *Context) Close() error {
+	contextM.Lock()
 	theContext = nil
+	contextM.Unlock()
 
 	if err := c.driverWriter.Close(); err != nil {
 		return err


### PR DESCRIPTION
Works on Windows 😃. Not sure about the other platforms.

Related to #47 