### PR TITLE
Bugfix, use alcGetString instead of alGetString

### DIFF
--- a/driver_openal.go
+++ b/driver_openal.go
@@ -129,7 +129,7 @@ func alFormat(channelNum, bitDepthInBytes int) C.ALenum {
 const numBufs = 2
 
 func newDriver(sampleRate, channelNum, bitDepthInBytes, bufferSizeInBytes int) (tryWriteCloser, error) {
-	name := C.alGetString(C.ALC_DEFAULT_DEVICE_SPECIFIER)
+	name := C.alcGetString(nil, C.ALC_DEFAULT_DEVICE_SPECIFIER)
 	d := alDevice(C._alcOpenDevice((*C.ALCchar)(name)))
 	if d == 0 {
 		return nil, fmt.Errorf("oto: alcOpenDevice must not return null")


### PR DESCRIPTION
Will allow for correct device names. Should not affect functionality.

## Context

Three important excepts from OpenAL's documentation:

1. `alGetString` does not support the parameters currently passed to it:
```
alGetString
Description
This function retrieves an OpenAL string property.
const ALchar * alGetString(
 ALenum param
);
Parameters
param The property to be returned
 AL_VENDOR
 AL_VERSION
 AL_RENDERER
 AL_EXTENSIONS 
```
2. `alcGetString` supports what we're trying to use `alGetString` to do:
```
To get the default device name, pass in NULL and
ALC_DEFAULT_DEVICE_SPECIFIER . 
```
3. `alcOpenDevice` was handling this error case correctly, silently. Since the return value from `alGetString` is `Null`, `alcOpenDevice` was functioning as expected, opening the default device, though not through the intended code-path.
```
The function call to open a device, alcOpenDevice, takes a string as input. The string should
contain either the name of a valid OpenAL rendering device, or NULL to request the default
device. 
```

So, in summary, `oto` was using the incorrect C functions, the particular null-values returned allowed this to go unnoticed silently, with the only side-effect being that the name of the device was not saved.