### PR TITLE
Use unsigned byte format on linux for compatability with other platforms

### DIFF
--- a/driver_linux.go
+++ b/driver_linux.go
@@ -99,7 +99,7 @@ func newDriver(sampleRate, numChans, bitDepthInBytes, bufferSizeInBytes int) (tr
 	var format C.snd_pcm_format_t
 	switch bitDepthInBytes {
 	case 1:
-		format = C.SND_PCM_FORMAT_S8
+		format = C.SND_PCM_FORMAT_U8
 	case 2:
 		format = C.SND_PCM_FORMAT_S16_LE
 	default:


### PR DESCRIPTION
On linux, `example/main.go` produces noticeably different output depending on the `bitDepthInBytes`. Executing `go run example/main.go -bitdepthinbytes=1` produces choppy audio, while `2` produces the expected sounds.

As best I can tell, this appears to be because `main.go` prepares an unsigned byte sample, while the format sent alsa is `SND_PCM_FORMAT_S8`. Changing this value to `SND_PCM_FORMAT_U8` makes the example behave as expected for `-bitdepthinbytes=1`.

I think this is a potentially breaking change, as someone who only targets linux might have realized this behaviour and written their code to account for it. But, I also think a breaking change would be justified here, as it brings the linux functionality to parity with the other platforms (and it's also pretty low impact since its targetting the worse quality of the two options).