### PR TITLE
Allowing creation of new context and new player

### DIFF
--- a/context.go
+++ b/context.go
@@ -82,9 +82,9 @@ func NewContext(sampleRate, channelNum, bitDepthInBytes, bufferSizeInBytes int) 
 	}
 	theContext = c
 	go func() {
-        if c.driverWriter == nil || c.mux == nil {
-            return
-        }
+		if c.driverWriter == nil || c.mux == nil {
+			return
+		}
 		if _, err := io.Copy(c.driverWriter, c.mux); err != nil {
 			c.errCh <- err
 		}

--- a/context.go
+++ b/context.go
@@ -82,6 +82,9 @@ func NewContext(sampleRate, channelNum, bitDepthInBytes, bufferSizeInBytes int) 
 	}
 	theContext = c
 	go func() {
+        if c.driverWriter == nil || c.mux == nil {
+            return
+        }
 		if _, err := io.Copy(c.driverWriter, c.mux); err != nil {
 			c.errCh <- err
 		}

--- a/player.go
+++ b/player.go
@@ -36,7 +36,6 @@ func newPlayer(context *Context) *Player {
 		r:       r,
 		w:       w,
 	}
-	runtime.SetFinalizer(p, (*Player).Close)
 	return p
 }
 


### PR DESCRIPTION
We ran into an issue where creating a new context and player caused a segmentation violation.

These modifications allow you to `player.Close` as you wish and make sure the `io.Copy` doesn't cause a segv.