### PR TITLE
Add *Context.Write to wrap player creation.

### DIFF
--- a/context.go
+++ b/context.go
@@ -122,6 +122,14 @@ func (c *Context) Close() error {
 	return <-c.errCh
 }
 
+// Write creates a new Player, writes to it, and closes it after the Write.
+func (c *Context) Write(buf []byte) (int, error) {
+	p := c.NewPlayer()
+	defer p.Close()
+
+	return p.Write(buf)
+}
+
 type tryWriteCloser interface {
 	io.Closer
 


### PR DESCRIPTION
Just ran into an unexpected bug, which ultimately was user error, but I think could be alleviated with a helper method on `*Context`.

The issue comes down to, when there is a delay between a writer being done writing, and the close of that writer, then the `bufio.Reader`, then the `Peek` here blocks until the `Player` is closed (or more data is written)

https://github.com/hajimehoshi/oto/blob/master/internal/mux/mux.go#L75

I think this isn't too outrageous. But it does mean that when I follow go convention and `defer p.Close()`, if there is an expensive operation that causes the `defer` to be delayed, then I'm going to get choppy audio. This is unexpected to me, because I expect `Close` methods to just be cleanup code, not really affecting the user experience when it happens.

By allowing this to instead take place in a function with a `*Context` receiver, we can avoid this potential bug.

Note that the reverse of this is true as well, Players which are instantiated early and not written to for some duration of time are going to cause choppy audio. To me this makes it clear that, if you only have one write, the code should always read:

```go
p := c.NewPlayer()
p.Write(buf)
p.Close()
```
Hence, the helper method on `*Context`.

Example code:

```go
package main

import (
	"math"
	"time"

	"github.com/hajimehoshi/oto"
)

func sin(x float64) float64 { return math.Sin(math.Pi * 2 * x) }

func good() {
	play := func(c *oto.Context, duration float64, freq float64) {
		sl := make([]byte, int(duration*44100))
		var f float64
		for i := range sl {
			f += freq * 1. / 44100
			sl[i] = byte(128 + 127*sin(f))
		}
		c.Write(sl)
		time.Sleep(time.Second / 5)
	}

	c, err := oto.NewContext(44100, 1, 1, 4096)
	if err != nil {
		panic(err)
	}
	for {
		go play(c, 1, 440)
		time.Sleep(time.Second / 2)
		go play(c, 1, 660)
		time.Sleep(time.Second / 2)
		go play(c, 1, 880)
		time.Sleep(time.Second / 2)
	}
}

func bad() {
	play := func(c *oto.Context, duration float64, freq float64) {
		sl := make([]byte, int(duration*44100))
		var f float64
		for i := range sl {
			f += freq * 1. / 44100
			sl[i] = byte(128 + 127*sin(f))
		}
		p := c.NewPlayer()
		p.Write(sl)
		defer p.Close()

		time.Sleep(time.Second / 5)
	}

	c, err := oto.NewContext(44100, 1, 1, 4096)
	if err != nil {
		panic(err)
	}
	for {
		go play(c, 1, 440)
		time.Sleep(time.Second / 2)
		go play(c, 1, 660)
		time.Sleep(time.Second / 2)
		go play(c, 1, 880)
		time.Sleep(time.Second / 2)
	}
}

func main() {
	//good()
	bad()
}
```