### PR TITLE
Output the offset value when in 1 bit depth

### DIFF
--- a/internal/mux/mux.go
+++ b/internal/mux/mux.go
@@ -62,8 +62,20 @@ func (m *Mux) Read(buf []byte) (int, error) {
 		if len(buf) < 256 {
 			n = len(buf)
 		}
-		copy(buf, make([]byte, n))
-		return n, nil
+
+		switch m.bitDepthInBytes {
+		case 1:
+			const offset = 128
+			for i := 0; i < n; i++ {
+				buf[i] = offset
+			}
+			return n, nil
+		case 2:
+			copy(buf, make([]byte, n))
+			return n, nil
+		default:
+			panic("not reached")
+		}
 	}
 
 	bs := m.channelNum * m.bitDepthInBytes


### PR DESCRIPTION
When using contexts with a bit depth of 1, there are audible pops ate the beginning and end of sounds when nothing else is playing. This fixes that by "zero-ing" the array to the `0` used later on to represent no sound, `128`. 