### PR TITLE
Add empty driver

### DIFF
--- a/driver_android.go
+++ b/driver_android.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build !noaudio
+
 package oto
 
 /*

--- a/driver_darwin.go
+++ b/driver_darwin.go
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 // +build !js
+// +build !noaudio
 
 package oto
 

--- a/driver_empty.go
+++ b/driver_empty.go
@@ -1,4 +1,4 @@
-// Copyright 2019 The Oto Authors
+// Copyright 2017 The Oto Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,17 +12,28 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build darwin,ios
-// +build !js
-// +build !noaudio
+// +build noaudio
 
 package oto
 
-// #cgo LDFLAGS: -framework Foundation -framework AVFoundation
-//
-// #import <AudioToolbox/AudioToolbox.h>
-import "C"
+import (
+	"fmt"
+	"unsafe"
+)
 
-func componentSubType() C.OSType {
-	return C.kAudioUnitSubType_RemoteIO
+type driver struct {
+}
+
+func newDriver(sampleRate, numChans, bitDepthInBytes, bufferSizeInBytes int) (tryWriteCloser, error) {
+	p := &driver{}
+
+	return p, nil
+}
+
+func (p *driver) TryWrite(data []byte) (n int, err error) {
+	return n, nil
+}
+
+func (p *driver) Close() error {
+	return nil
 }

--- a/driver_empty.go
+++ b/driver_empty.go
@@ -16,11 +16,6 @@
 
 package oto
 
-import (
-	"fmt"
-	"unsafe"
-)
-
 type driver struct {
 }
 

--- a/driver_ios.m
+++ b/driver_ios.m
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 // +build darwin,ios
+// +build !noaudio
 
 #import <AVFoundation/AVFoundation.h>
 #import <AudioToolbox/AudioToolbox.h>

--- a/driver_js.go
+++ b/driver_js.go
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 // +build js
+// +build !noaudio
 
 package oto
 

--- a/driver_linux.go
+++ b/driver_linux.go
@@ -15,6 +15,7 @@
 // +build !js
 // +build !android
 // +build !ios
+// +build !noaudio
 
 package oto
 

--- a/driver_macos.go
+++ b/driver_macos.go
@@ -14,6 +14,7 @@
 
 // +build darwin,!ios
 // +build !js
+// +build !noaudio
 
 package oto
 

--- a/driver_macos.m
+++ b/driver_macos.m
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 // +build darwin,!ios,!js
+// +build !noaudio
 
 #import <AppKit/AppKit.h>
 

--- a/driver_openal.go
+++ b/driver_openal.go
@@ -15,6 +15,7 @@
 // +build freebsd openbsd
 // +build !js
 // +build !android
+// +build !noaudio
 
 package oto
 

--- a/driver_windows.go
+++ b/driver_windows.go
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 // +build !js
+// +build !noaudio
 
 package oto
 


### PR DESCRIPTION
I had to create an empty driver for my project, which doesn't need audio, but engo depends on oto.
Without this driver I wasn't able to build the project, because it needed alsa to be installed.

The driver itself doesn't do anything, but it also doesn't depend on external programs. 
Thought, someone else might also find this useful for testing or if they are using libraries, which depend on oto, on a server.

You can choose the driver by adding the `noaudio` build tag. 