### PR TITLE
android: Added code path for low latency audio if available

### DIFF
--- a/driver_android.go
+++ b/driver_android.go
@@ -18,7 +18,6 @@ package oto
 
 #include <jni.h>
 #include <stdlib.h>
-#include <stdbool.h>
 
 static jclass android_media_AudioFormat;
 static jclass android_media_AudioManager;
@@ -97,6 +96,8 @@ static char* initAudioTrack(uintptr_t java_vm, uintptr_t jni_env,
     return "invalid bitDepthInBytes";
   }
 
+  // If the available Android SDK is at least 24 (7.0 Nougat), the FLAG_LOW_LATENCY is available.
+  // This requires a different constructor.
   if (availableSDK >= 24) {
     jclass android_media_AudioAttributes_Builder;
     jclass android_media_AudioFormat_Builder;


### PR DESCRIPTION
This change uses the FLAG_LOW_LATENCY flag on Android if it is available, and falls back to the previous way if not. 

The only downside I see is that in low latency mode the phone may skip some processing. On my phone the audio is noticeably louder in the low latency mode for some reason. But the latency was too high for me, so this is nevertheless preferable. It's up to you though.