### PR TITLE
windows: do not reallocate temp buffer every time

### DIFF
--- a/driver_windows.go
+++ b/driver_windows.go
@@ -126,7 +126,7 @@ func (p *driver) TryWrite(data []byte) (int, error) {
 		return 0, err
 	}
 
-	p.tmp = nil
+	p.tmp = p.tmp[:0]
 	return n, nil
 }
 


### PR DESCRIPTION
Reuse the allocated temp buffer by just setting its length to zero, instead of assigning it to nil. Produces less garbage.