### PR TITLE
Prevent Invalid Access Exceptions on Windows

### DIFF
--- a/driver_windows.go
+++ b/driver_windows.go
@@ -132,10 +132,17 @@ func (p *driver) TryWrite(data []byte) (int, error) {
 
 func (p *driver) Close() error {
 	runtime.SetFinalizer(p, nil)
+
 	// TODO: Call waveOutUnprepareHeader here
+
+	if err := waveOutReset(p.out); err != nil {
+		return err
+	}
+
 	if err := waveOutClose(p.out); err != nil {
 		return err
 	}
+
 	return nil
 }
 

--- a/winmm_windows.go
+++ b/winmm_windows.go
@@ -32,6 +32,7 @@ var (
 	procWaveOutOpen          = winmm.NewProc("waveOutOpen")
 	procWaveOutClose         = winmm.NewProc("waveOutClose")
 	procWaveOutPrepareHeader = winmm.NewProc("waveOutPrepareHeader")
+	procWaveOutReset         = winmm.NewProc("waveOutReset")
 	procWaveOutWrite         = winmm.NewProc("waveOutWrite")
 )
 
@@ -178,6 +179,25 @@ func waveOutPrepareHeader(hwo uintptr, pwh *wavehdr) error {
 			mmresult: mmresult(r),
 		}
 	}
+	return nil
+}
+
+func waveOutReset(hwo uintptr) error {
+	r, _, e := procWaveOutReset.Call(hwo)
+	if e.(windows.Errno) != 0 {
+		return &winmmError{
+			fname: "waveOutReset",
+			errno: e.(windows.Errno),
+		}
+	}
+
+	if mmresult(r) != mmsyserrNoerror {
+		return &winmmError{
+			fname:    "waveOutReset",
+			mmresult: mmresult(r),
+		}
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
https://docs.microsoft.com/en-us/previous-versions/dd743856(v=vs.85)#remarks

Calling `waveOutReset` explicitly before `waveOutClose` to handle cases where the user calls `Close()` before the buffers are finished.