### PR TITLE
Use a `__stdcall` callback, not a `__cdecl` one, for waveOutOpen.

### DIFF
--- a/driver_windows.go
+++ b/driver_windows.go
@@ -181,7 +181,7 @@ func (c *context) isHeaderAvailable() bool {
 	return false
 }
 
-var waveOutOpenCallback = windows.NewCallbackCDecl(func(hwo, uMsg, dwInstance, dwParam1, dwParam2 uintptr) uintptr {
+var waveOutOpenCallback = windows.NewCallback(func(hwo, uMsg, dwInstance, dwParam1, dwParam2 uintptr) uintptr {
 	// Queuing a header in this callback might not work especially when a headset is connected or disconnected.
 	// Just signal the condition vairable and don't do other things.
 	const womDone = 0x3bd


### PR DESCRIPTION
On 64-bit systems this distinction does not matter; on WINE things oddly work
either way (it is in theory possible for a caller to support both, as these
two differ only in how they return, not in how they pass arguments).

Fixes crash on Windows 7 x86.

Fixes #158.