### PR TITLE
doc: remove language about closing contexts

### DIFF
--- a/driver.go
+++ b/driver.go
@@ -23,8 +23,6 @@ import (
 //
 // To play sound with Oto, first create a context. Then use the context to create
 // an arbitrary number of players. Then use the players to play sound.
-//
-// There can only be one context at any time. Closing a context and opening a new one is allowed.
 type Context struct {
 	context *context
 }


### PR DESCRIPTION
As I understand it, the v2 oto API no longer provides a facility to close contexts, and it also no longer needs contexts to be closed. This just drops a comment that references closing contexts.