### PR TITLE
Mention C/C++ compiler requirement in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A low-level library to play sound.
 - [Oto (v2)](#oto-v2)
   - [Platforms](#platforms)
   - [Prerequisite](#prerequisite)
-    - [MacOS](#macos)
+    - [macOS](#macos)
     - [iOS](#ios)
     - [Linux](#linux)
     - [FreeBSD, OpenBSD](#freebsd-openbsd)
@@ -20,7 +20,7 @@ A low-level library to play sound.
 ## Platforms
 
 - Windows
-- MacOS
+- macOS
 - Linux
 - FreeBSD
 - OpenBSD
@@ -32,11 +32,11 @@ A low-level library to play sound.
 
 On some platforms you will need a C/C++ compiler in your path that Go can use.
 
-- MacOS: On newer MacOS versions type `clang` on your terminal and a dialog with installation instructions will appear if you don't have it
+- macOS: On newer macOS versions type `clang` on your terminal and a dialog with installation instructions will appear if you don't have it
   - If you get an error with clang use xcode instead `xcode-select --install`
 - Linux and other Unix systems: Should be installed by default, but if not try [GCC](https://gcc.gnu.org/) or [Clang](https://releases.llvm.org/download.html)
 
-### MacOS
+### macOS
 
 Oto requires `AudioToolbox.framework`, but this is automatically linked.
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,11 @@ A low-level library to play sound.
 
 ## Prerequisite
 
+On most platforms you will need a C/C++ compiler in your path that Go can use.
+
+- Windows: [MingW](https://www.mingw-w64.org/downloads/#mingw-builds) or similar
+- Mac/Linux: Should be installed by default, but if not try [GCC](https://gcc.gnu.org/) or [Clang](https://releases.llvm.org/download.html)
+
 ### macOS
 
 Oto requires `AudioToolbox.framework`, but this is automatically linked.

--- a/README.md
+++ b/README.md
@@ -30,10 +30,11 @@ A low-level library to play sound.
 
 ## Prerequisite
 
-On most platforms you will need a C/C++ compiler in your path that Go can use.
+On some platforms you will need a C/C++ compiler in your path that Go can use.
 
-- Windows: [MingW](https://www.mingw-w64.org/downloads/#mingw-builds) or similar
-- Mac/Linux: Should be installed by default, but if not try [GCC](https://gcc.gnu.org/) or [Clang](https://releases.llvm.org/download.html)
+- Linux: Should be installed by default, but if not try [GCC](https://gcc.gnu.org/) or [Clang](https://releases.llvm.org/download.html)
+- MacOS: On newer macOS versions type `clang` on your terminal and a dialog with installation instructions will appear if you don't have it
+  - If you get an error with clang use xcode instead `xcode-select --install`
 
 ### macOS
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A low-level library to play sound.
 - [Oto (v2)](#oto-v2)
   - [Platforms](#platforms)
   - [Prerequisite](#prerequisite)
-    - [macOS](#macos)
+    - [MacOS](#macos)
     - [iOS](#ios)
     - [Linux](#linux)
     - [FreeBSD, OpenBSD](#freebsd-openbsd)
@@ -20,7 +20,7 @@ A low-level library to play sound.
 ## Platforms
 
 - Windows
-- macOS
+- MacOS
 - Linux
 - FreeBSD
 - OpenBSD
@@ -32,11 +32,11 @@ A low-level library to play sound.
 
 On some platforms you will need a C/C++ compiler in your path that Go can use.
 
-- Linux: Should be installed by default, but if not try [GCC](https://gcc.gnu.org/) or [Clang](https://releases.llvm.org/download.html)
-- MacOS: On newer macOS versions type `clang` on your terminal and a dialog with installation instructions will appear if you don't have it
+- MacOS: On newer MacOS versions type `clang` on your terminal and a dialog with installation instructions will appear if you don't have it
   - If you get an error with clang use xcode instead `xcode-select --install`
+- Linux and other Unix systems: Should be installed by default, but if not try [GCC](https://gcc.gnu.org/) or [Clang](https://releases.llvm.org/download.html)
 
-### macOS
+### MacOS
 
 Oto requires `AudioToolbox.framework`, but this is automatically linked.
 


### PR DESCRIPTION
I noticed that Oto uses CGO, but we haven't mentioned it anywhere in the README, so this is a small update to add a mention about that.