### PR TITLE
Docs: Use io.Seeker instead of Reset in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A low-level library to play sound.
 - [Oto (v2)](#oto-v2)
   - [Platforms](#platforms)
   - [Prerequisite](#prerequisite)
-    - [MacOS](#macos)
+    - [macOS](#macos)
     - [iOS](#ios)
     - [Linux](#linux)
     - [FreeBSD, OpenBSD](#freebsd-openbsd)
@@ -20,7 +20,7 @@ A low-level library to play sound.
 ## Platforms
 
 - Windows
-- MacOS
+- macOS
 - Linux
 - FreeBSD
 - OpenBSD
@@ -32,11 +32,11 @@ A low-level library to play sound.
 
 On some platforms you will need a C/C++ compiler in your path that Go can use.
 
-- MacOS: On newer MacOS versions type `clang` on your terminal and a dialog with installation instructions will appear if you don't have it
+- macOS: On newer macOS versions type `clang` on your terminal and a dialog with installation instructions will appear if you don't have it
   - If you get an error with clang use xcode instead `xcode-select --install`
 - Linux and other Unix systems: Should be installed by default, but if not try [GCC](https://gcc.gnu.org/) or [Clang](https://releases.llvm.org/download.html)
 
-### MacOS
+### macOS
 
 Oto requires `AudioToolbox.framework`, but this is automatically linked.
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,11 @@ A low-level library to play sound.
 
 ## Prerequisite
 
+On most platforms you will need a C/C++ compiler in your path that Go can use.
+
+- Windows: [MingW](https://www.mingw-w64.org/downloads/#mingw-builds) or similar
+- Mac/Linux: Should be installed by default, but if not try [GCC](https://gcc.gnu.org/) or [Clang](https://releases.llvm.org/download.html)
+
 ### macOS
 
 Oto requires `AudioToolbox.framework`, but this is automatically linked.

--- a/README.md
+++ b/README.md
@@ -138,6 +138,10 @@ func main() {
 
     // Now that the sound finished playing, we can restart from the beginning (or go to any location in the sound) using seek
     // newPos, err := player.(io.Seeker).Seek(0, io.SeekStart)
+    // if err != nil{
+    //     panic("Seeker is broken. Err: " + err.Error())
+    // }
+    // println("Player is now at position:", newPos)
     // player.Play()
 
     // If you don't want the player/sound anymore simply close

--- a/README.md
+++ b/README.md
@@ -30,10 +30,11 @@ A low-level library to play sound.
 
 ## Prerequisite
 
-On most platforms you will need a C/C++ compiler in your path that Go can use.
+On some platforms you will need a C/C++ compiler in your path that Go can use.
 
-- Windows: [MingW](https://www.mingw-w64.org/downloads/#mingw-builds) or similar
-- Mac/Linux: Should be installed by default, but if not try [GCC](https://gcc.gnu.org/) or [Clang](https://releases.llvm.org/download.html)
+- Linux: Should be installed by default, but if not try [GCC](https://gcc.gnu.org/) or [Clang](https://releases.llvm.org/download.html)
+- MacOS: On newer macOS versions type `clang` on your terminal and a dialog with installation instructions will appear if you don't have it
+  - If you get an error with clang use xcode instead `xcode-select --install`
 
 ### macOS
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A low-level library to play sound.
 - [Oto (v2)](#oto-v2)
   - [Platforms](#platforms)
   - [Prerequisite](#prerequisite)
-    - [macOS](#macos)
+    - [MacOS](#macos)
     - [iOS](#ios)
     - [Linux](#linux)
     - [FreeBSD, OpenBSD](#freebsd-openbsd)
@@ -20,7 +20,7 @@ A low-level library to play sound.
 ## Platforms
 
 - Windows
-- macOS
+- MacOS
 - Linux
 - FreeBSD
 - OpenBSD
@@ -32,11 +32,11 @@ A low-level library to play sound.
 
 On some platforms you will need a C/C++ compiler in your path that Go can use.
 
-- Linux: Should be installed by default, but if not try [GCC](https://gcc.gnu.org/) or [Clang](https://releases.llvm.org/download.html)
-- MacOS: On newer macOS versions type `clang` on your terminal and a dialog with installation instructions will appear if you don't have it
+- MacOS: On newer MacOS versions type `clang` on your terminal and a dialog with installation instructions will appear if you don't have it
   - If you get an error with clang use xcode instead `xcode-select --install`
+- Linux and other Unix systems: Should be installed by default, but if not try [GCC](https://gcc.gnu.org/) or [Clang](https://releases.llvm.org/download.html)
 
-### macOS
+### MacOS
 
 Oto requires `AudioToolbox.framework`, but this is automatically linked.
 

--- a/README.md
+++ b/README.md
@@ -136,8 +136,8 @@ func main() {
         time.Sleep(time.Millisecond)
     }
 
-    // Now that the sound finished playing, we can restart from the beginning using these two lines
-    // player.Reset()
+    // Now that the sound finished playing, we can restart from the beginning (or go to any location in the sound) using seek
+    // player.(io.Seeker).Seek(0, io.SeekStart)
     // player.Play()
 
     // If you don't want the player/sound anymore simply close

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ func main() {
     }
 
     // Now that the sound finished playing, we can restart from the beginning (or go to any location in the sound) using seek
-    // player.(io.Seeker).Seek(0, io.SeekStart)
+    // newPos, err := player.(io.Seeker).Seek(0, io.SeekStart)
     // player.Play()
 
     // If you don't want the player/sound anymore simply close


### PR DESCRIPTION
Now that https://github.com/hajimehoshi/oto/issues/172 is looking good and 19c3101d30142518729150dc41b54752776b14f8 is there we can update the docs.

This should probably be merged along with a new release.