### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ A low-level library to play sound.
 
 ## Platforms
 
-- Windows
-- macOS
+- Windows (no Cgo!)
+- macOS (no Cgo!)
 - Linux
 - FreeBSD
 - OpenBSD
@@ -34,7 +34,7 @@ A low-level library to play sound.
 
 On some platforms you will need a C/C++ compiler in your path that Go can use.
 
-- macOS: On newer macOS versions type `clang` on your terminal and a dialog with installation instructions will appear if you don't have it
+- iOS: On newer macOS versions type `clang` on your terminal and a dialog with installation instructions will appear if you don't have it
   - If you get an error with clang use xcode instead `xcode-select --install`
 - Linux and other Unix systems: Should be installed by default, but if not try [GCC](https://gcc.gnu.org/) or [Clang](https://releases.llvm.org/download.html)
 
@@ -218,4 +218,7 @@ This works because players implement a `Player` interface and a `BufferSizeSette
 
 ## Crosscompiling
 
-To crosscompile, make sure the libraries for the target architecture are installed, and set `CGO_ENABLED=1` as Go disables [Cgo](https://golang.org/cmd/cgo/#hdr-Using_cgo_with_the_go_command) on crosscompiles by default.
+Crosscompiling to macOS or Windows is as easy as setting `GOOS=darwin` or `GOOS=windows`, respectively.
+
+To crosscompile for other platforms, make sure the libraries for the target architecture are installed, and set 
+`CGO_ENABLED=1` as Go disables [Cgo](https://golang.org/cmd/cgo/#hdr-Using_cgo_with_the_go_command) on crosscompiles by default.


### PR DESCRIPTION
Oto no longer requires a C compiler to target macOS. This PR updates the README.md to express this change.