### PR TITLE
internal/mux: bug fix: unlock when calling an external function

### DIFF
--- a/internal/mux/mux.go
+++ b/internal/mux/mux.go
@@ -260,7 +260,6 @@ func (p *playerImpl) playImpl() {
 
 	if p.eof && len(p.buf) == 0 {
 		p.state = playerPaused
-		return
 	}
 
 	p.m.Unlock()


### PR DESCRIPTION
We cannot expect what would happen in an external function call, and this might block unexpectedly. Actually this causes stutters.

This changes fixes this issue by not locking when calling an external interface function Read.

Closes #188