### PR TITLE
readme: add setup instruction for redhat-based linux distros

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,12 @@ ALSA is required. On Ubuntu or Debian, run this command:
 apt install libasound2-dev
 ```
 
+On RedHat-based linux distributions run:
+
+```sh
+dnf install alsa-lib-devel
+```
+
 In most cases this command must be run by root user or through `sudo` command.
 
 ### FreeBSD, OpenBSD

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ ALSA is required. On Ubuntu or Debian, run this command:
 apt install libasound2-dev
 ```
 
-On RedHat-based linux distributions run:
+On RedHat-based linux distributions, run:
 
 ```sh
 dnf install alsa-lib-devel


### PR DESCRIPTION
Hi
a small readme update:
SInce I'm using Fedora I've noticed that the package name is diffrent than ubuntu/debian's one.