### PR TITLE
Update purego

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/hajimehoshi/oto/v2
 go 1.18
 
 require (
-	github.com/ebitengine/purego v0.2.0-alpha.0.20221019153918-7128aea44c77
+	github.com/ebitengine/purego v0.2.0-alpha.0.20221104133025-13a6f7821dfb
 	golang.org/x/sys v0.1.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
-github.com/ebitengine/purego v0.2.0-alpha.0.20221019153918-7128aea44c77 h1:EtWqfTv9g2m5Q8YF2hZVlwvBnA1V5ndO9pmwgrA3FNg=
-github.com/ebitengine/purego v0.2.0-alpha.0.20221019153918-7128aea44c77/go.mod h1:8K86Hsai2ghNjg9h/9P9tDdLAhUNwqNg10OESLDOam8=
+github.com/ebitengine/purego v0.2.0-alpha.0.20221104133025-13a6f7821dfb h1:wH2M2HH5XBVqFCd4aLkKlK44NVKrDca/UlWmStRTiHk=
+github.com/ebitengine/purego v0.2.0-alpha.0.20221104133025-13a6f7821dfb/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
 golang.org/x/sys v0.1.0 h1:kunALQeHf1/185U1i0GOB/fy1IPRDDpuoOOqRReG57U=
 golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=


### PR DESCRIPTION
Oto needs to be updated in order to update Ebitengine. Otherwise, the program locks up.