### PR TITLE
Oto 1.0 driver for the Kinc library

### DIFF
--- a/driver_darwin.go
+++ b/driver_darwin.go
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build !js
-// +build !js
+//go:build !js && !kinc
+// +build !js && !kinc
 
 package oto
 

--- a/driver_kinc.go
+++ b/driver_kinc.go
@@ -1,0 +1,97 @@
+// Copyright 2022 Sam Hocevar <sam@hocevar.net>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the license.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build kinc
+// +build kinc
+
+package oto
+
+/*
+#include <kinc/audio2/audio.h>
+
+typedef void (*audio_callback_t)(kinc_a2_buffer_t *buffer, int samples);
+typedef void (*sample_rate_callback_t)(void);
+
+void audio_callback(kinc_a2_buffer_t *buffer, int samples);
+void sample_rate_callback(void);
+*/
+import "C"
+
+import (
+	"unsafe"
+)
+
+const (
+	BufferLength = 4096 // Max number of samples in our audio buffer
+)
+
+type driver struct {
+	buf	[]byte // Holds int16 data
+}
+
+var gDriver *driver
+
+//export audio_callback
+func audio_callback(buffer *C.kinc_a2_buffer_t, samples int32) {
+	// TODO: buffer.write_location and buffer.read_location may give us a good
+	// hint about the buffer status and decide whether we need to hurry up to
+	// avoid stuttering.
+	canRead := len(gDriver.buf) / 2
+	toWrite := min(canRead, int(samples))
+	for i := 0; i < toWrite; i++ {
+
+		sample := *(*int16)(unsafe.Pointer(uintptr(unsafe.Pointer(&gDriver.buf[0])) + uintptr(i * 2)))
+		*(*float32)(unsafe.Pointer(uintptr(unsafe.Pointer(buffer.data)) + uintptr(buffer.write_location))) = float32(sample) / 32768.
+
+		buffer.write_location += 4
+		if buffer.write_location >= buffer.data_size {
+			buffer.write_location = 0
+		}
+	}
+	gDriver.buf = gDriver.buf[toWrite * 2:]
+}
+
+//export sample_rate_callback
+func sample_rate_callback() {
+	// TODO: handle rate changes?
+}
+
+func newDriver(sampleRate, numChans, bitDepthInBytes, bufferSizeInBytes int) (tryWriteCloser, error) {
+	p := &driver{
+		[]byte{},
+	}
+
+	C.kinc_a2_init()
+	C.kinc_a2_set_callback((C.audio_callback_t)(C.audio_callback))
+	gDriver = p
+
+	return p, nil
+}
+
+func (p *driver) TryWrite(data []byte) (n int, err error) {
+	toAppend := min(len(data), max(0, BufferLength - len(p.buf)))
+	p.buf = append(p.buf, data[:toAppend]...)
+	return toAppend, nil
+}
+
+func (p *driver) Close() error {
+	C.kinc_a2_shutdown()
+	gDriver = nil
+
+	return nil
+}
+
+func (d *driver) tryWriteCanReturnWithoutWaiting() bool {
+	return true
+}

--- a/driver_linux.go
+++ b/driver_linux.go
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build !js && !android && !ios
-// +build !js,!android,!ios
+//go:build !js && !android && !ios && !kinc
+// +build !js,!android,!ios,!kinc
 
 package oto
 

--- a/driver_macos.go
+++ b/driver_macos.go
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build darwin && !ios && !js
-// +build darwin,!ios,!js
+//go:build darwin && !ios && !js && !kinc
+// +build darwin,!ios,!js,!kinc
 
 package oto
 

--- a/driver_windows.go
+++ b/driver_windows.go
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build !js
-// +build !js
+//go:build !js && !kinc
+// +build !js,!kinc
 
 package oto
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/hajimehoshi/oto
 
-go 1.13
+go 1.17
 
 require (
 	golang.org/x/mobile v0.0.0-20190415191353-3e0bab5405d6

--- a/winmm_windows.go
+++ b/winmm_windows.go
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build !js
-// +build !js
+//go:build !js && !kinc
+// +build !js && !kinc
 
 package oto
 


### PR DESCRIPTION
I’m sorry that this is PR is against the 1.0 branch, but as you have seen, the Beep library is taking forever to transition to Oto 2.x (https://github.com/faiface/beep/pull/130) so I think it’s still worth having it in Oto 1.0.

This driver is activated when building with `-tags kinc`. It uses the Kinc library (https://github.com/Kode/Kinc) which is a low-level multiplatform framework similar to SDL.

I have successfully tested the driver on the following platforms:
 - Windows x64
 - Linux x64
 - Xbox One
 - Xbox Series X
 - PlayStation 5
 - Nintendo Switch

The driver also compiles properly for the PlayStation 4, but I do not have the appropriate hardware to test it. Given that it works flawlessly on all the other platforms and there is no platform-specific code, I’m not too worried.