### PR TITLE
Clarify Cgo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ A low-level library to play sound.
 
 ## Platforms
 
-- Windows (no Cgo!)
-- macOS (no Cgo!)
+- Windows (no Cgo required!)
+- macOS (no Cgo required!)
 - Linux
 - FreeBSD
 - OpenBSD


### PR DESCRIPTION
This is just a little tweak to clarify that Cgo isn't required for Windows/MacOS. As currently written it could read as 'not required', but also as 'not allowed'.