### PR TITLE
all: update pulse library to support BSDs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,6 @@ go 1.25.0
 
 require (
 	github.com/ebitengine/purego v0.10.2
-	github.com/jfreymuth/pulse v0.1.2
+	github.com/jfreymuth/pulse v0.1.3
 	golang.org/x/sys v0.47.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,6 @@
 github.com/ebitengine/purego v0.10.2 h1:W809HbnvzAxgdm+aOvlSekrM16wGCdT/e76+9tS7gzE=
 github.com/ebitengine/purego v0.10.2/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
-github.com/jfreymuth/pulse v0.1.2 h1:t4+ItUuWLlQnulVDOL2eAotKk+utKJzK8ol0iybYAmQ=
-github.com/jfreymuth/pulse v0.1.2/go.mod h1:cpYspI6YljhkUf1WLXLLDmeaaPFc3CnGLjDZf9dZ4no=
+github.com/jfreymuth/pulse v0.1.3 h1:bc5TdxiB8E+2INnFjFWWgyfgXtz2IyNNNCX+Wt/ZD14=
+github.com/jfreymuth/pulse v0.1.3/go.mod h1:cpYspI6YljhkUf1WLXLLDmeaaPFc3CnGLjDZf9dZ4no=
 golang.org/x/sys v0.47.0 h1:o7XGOvZQCADBQQ4Y7VNq2dRWQR7JmOUW8Kxx4ZsNgWs=
 golang.org/x/sys v0.47.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=


### PR DESCRIPTION
Previously, oto didn't work out of the box on OpenBSD (and probably other BSDs). The `PULSE_SERVER` environment variable had to be set manually, so that pulse could be used to play audio. With this pull request, a sensible default is used and oto works out of the box on OpenBSD.

See https://github.com/jfreymuth/pulse/pull/47